### PR TITLE
Get userinfo from /userinfo endpoint

### DIFF
--- a/01-Login/auth0login/auth0backend.py
+++ b/01-Login/auth0login/auth0backend.py
@@ -1,5 +1,4 @@
-from six.moves.urllib import request
-from jose import jwt
+import requests
 from social_core.backends.oauth import BaseOAuth2
 
 
@@ -23,14 +22,12 @@ class Auth0(BaseOAuth2):
         return details['user_id']
 
     def get_user_details(self, response):
-        # Obtain JWT and the keys to validate the signature
-        idToken = response.get('id_token')
-        jwks = request.urlopen("https://" + self.setting('DOMAIN') + "/.well-known/jwks.json")
-        issuer = "https://" + self.setting('DOMAIN') + "/"
-        audience = self.setting('KEY') #CLIENT_ID
-        payload = jwt.decode(idToken, jwks.read(), algorithms=['RS256'], audience=audience, issuer=issuer)
+        url = 'https://' + self.setting('DOMAIN') + '/userinfo'
+        headers = {'authorization': 'Bearer ' + response['access_token']}
+        resp = requests.get(url, headers=headers)
+        userinfo = resp.json()
 
-        return {'username': payload['nickname'],
-                'first_name': payload['name'],
-                'picture': payload['picture'],
-                'user_id': payload['sub']}
+        return {'username': userinfo['nickname'],
+                'first_name': userinfo['name'],
+                'picture': userinfo['picture'],
+                'user_id': userinfo['sub']}

--- a/01-Login/requirements.txt
+++ b/01-Login/requirements.txt
@@ -1,5 +1,4 @@
 django
 social-auth-app-django
-python-jose
-six
 python-dotenv
+requests

--- a/01-Login/requirements.txt
+++ b/01-Login/requirements.txt
@@ -1,4 +1,4 @@
-django<=1.11
+django>=1.11.4, <2.0
 social-auth-app-django
 python-dotenv
 requests


### PR DESCRIPTION
Get user profile from `/userinfo` endpoint instead of decode it from `id_token`.
Fixes #7.