### PR TITLE
Authentication backends setting should be a list

### DIFF
--- a/01-Login/webappexample/settings.py
+++ b/01-Login/webappexample/settings.py
@@ -144,10 +144,10 @@ else:
         AUDIENCE = 'https://' + SOCIAL_AUTH_AUTH0_DOMAIN + '/userinfo'
 if AUDIENCE:
     SOCIAL_AUTH_AUTH0_AUTH_EXTRA_ARGUMENTS = {'audience': AUDIENCE}
-AUTHENTICATION_BACKENDS = {
+AUTHENTICATION_BACKENDS = [
     'auth0login.auth0backend.Auth0',
-    'django.contrib.auth.backends.ModelBackend'
-}
+    'django.contrib.auth.backends.ModelBackend',
+]
 
 
 LOGIN_URL = "/login/auth0"


### PR DESCRIPTION
As the documentation states, the authentication backends settings should be a list not a set. This could introduce a problem since sets are not ordered

https://docs.djangoproject.com/en/2.1/topics/auth/customizing/#specifying-authentication-backends