### PR TITLE
Prevent multiple user logins

### DIFF
--- a/01-Login/auth0login/auth0backend.py
+++ b/01-Login/auth0login/auth0backend.py
@@ -10,7 +10,8 @@ class Auth0(BaseOAuth2):
     ACCESS_TOKEN_METHOD = 'POST'
     REDIRECT_STATE = False
     EXTRA_DATA = [
-        ('picture', 'picture')
+        ('picture', 'picture'),
+        ('email', 'email')
     ]
 
     def authorization_url(self):
@@ -30,8 +31,8 @@ class Auth0(BaseOAuth2):
         issuer = 'https://' + self.setting('DOMAIN') + '/'
         audience = self.setting('KEY')  # CLIENT_ID
         payload = jwt.decode(id_token, jwks.read(), algorithms=['RS256'], audience=audience, issuer=issuer)
-
         return {'username': payload['nickname'],
                 'first_name': payload['name'],
                 'picture': payload['picture'],
-                'user_id': payload['sub']}
+                'user_id': payload['sub'],
+                'email': payload['email']}

--- a/01-Login/auth0login/auth0backend.py
+++ b/01-Login/auth0login/auth0backend.py
@@ -8,6 +8,7 @@ class Auth0(BaseOAuth2):
     name = 'auth0'
     SCOPE_SEPARATOR = ' '
     ACCESS_TOKEN_METHOD = 'POST'
+    REDIRECT_STATE = False
     EXTRA_DATA = [
         ('picture', 'picture')
     ]

--- a/01-Login/auth0login/views.py
+++ b/01-Login/auth0login/views.py
@@ -1,4 +1,4 @@
-from django.shortcuts import render
+from django.shortcuts import render, redirect
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth import logout as log_out
 from django.conf import settings
@@ -9,7 +9,11 @@ import json
 
 
 def index(request):
-    return render(request, 'index.html')
+    user = request.user
+    if user.is_authenticated:
+        return redirect(dashboard)
+    else:
+        return render(request, 'index.html')
 
 
 @login_required

--- a/01-Login/auth0login/views.py
+++ b/01-Login/auth0login/views.py
@@ -23,7 +23,8 @@ def dashboard(request):
     userdata = {
         'user_id': auth0user.uid,
         'name': user.first_name,
-        'picture': auth0user.extra_data['picture']
+        'picture': auth0user.extra_data['picture'],
+        'email': auth0user.extra_data['email']
     }
 
     return render(request, 'dashboard.html', {

--- a/01-Login/webappexample/settings.py
+++ b/01-Login/webappexample/settings.py
@@ -133,7 +133,8 @@ SOCIAL_AUTH_AUTH0_KEY = os.environ.get('AUTH0_CLIENT_ID')
 SOCIAL_AUTH_AUTH0_SECRET = os.environ.get('AUTH0_CLIENT_SECRET')
 SOCIAL_AUTH_AUTH0_SCOPE = [
     'openid',
-    'profile'
+    'profile',
+    'email'
 ]
 SOCIAL_AUTH_AUTH0_DOMAIN = os.environ.get('AUTH0_DOMAIN')
 AUDIENCE = None


### PR DESCRIPTION
This PR adds a check for preventing multiple users from logging in, by checking whether a user is already logged in when the index view is displayed and redirecting to the dashboard view.

It also prevents the `redirect_state` query param to be appended to the `redirect_uri` URL. This doesn't affect the `state` param, which is sent anyway.

Finally, the default scope was added `email` and the email attribute mapped as an `extra_data` parameter. The dashboard view was updated to show it inside the code snippet block.


**Docs PR:**  https://github.com/auth0/docs/pull/8183