### PR TITLE
Solved python3 compatibility issue. Solves issue #26 a bytes-like object is required, not 'str'

### DIFF
--- a/01-Login/auth0login/auth0backend.py
+++ b/01-Login/auth0login/auth0backend.py
@@ -30,7 +30,9 @@ class Auth0(BaseOAuth2):
         jwks = request.urlopen('https://' + self.setting('DOMAIN') + '/.well-known/jwks.json')
         issuer = 'https://' + self.setting('DOMAIN') + '/'
         audience = self.setting('KEY')  # CLIENT_ID
-        payload = jwt.decode(id_token, jwks.read(), algorithms=['RS256'], audience=audience, issuer=issuer)
+        # convert to list str
+        jws_read = bytearray(jwks.read()).decode('ascii')
+        payload = jwt.decode(id_token, jws_read, algorithms=['RS256'], audience=audience, issuer=issuer)
         return {'username': payload['nickname'],
                 'first_name': payload['name'],
                 'picture': payload['picture'],


### PR DESCRIPTION
I just added one line of code that solves the error when trying to read the jwks variable