### PR TITLE
add lang attribute, description and viewport meta tags

### DIFF
--- a/01-Login/webappexample/templates/index.html
+++ b/01-Login/webappexample/templates/index.html
@@ -1,7 +1,9 @@
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <title>Auth0 Example</title>
+    <meta name="description" content="an example app showing Auth0 integration with Django">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
   </head>
   <body>
     {% if session %}


### PR DESCRIPTION
these are important for accessibility, so we should have defaults set up in the example in case people adapt it for production use.